### PR TITLE
Improve course flow and add example content

### DIFF
--- a/AbueTech/JS/inicio.js
+++ b/AbueTech/JS/inicio.js
@@ -208,10 +208,25 @@ if (menu.classList.contains('active')) {
 });
 
 // Procesar pago simulado
+function getQueryParam(param) {
+    const params = new URLSearchParams(window.location.search);
+    return params.get(param);
+}
+
 function processPayment(event) {
     event.preventDefault();
     const form = event.target;
     const name = form.querySelector('input[name="name"]').value;
-    alert(`\u00a1Gracias, ${name}! Tu pago se ha realizado correctamente.`);
+    const course = getQueryParam('course') || 'basico';
+
+    const successDiv = document.getElementById('payment-success');
+    const messageP = document.getElementById('success-message');
+    const link = document.getElementById('course-link');
+
+    messageP.textContent = `¡Gracias, ${name}! Tu pago se ha realizado correctamente.`;
+    link.href = `curso_${course}.html`;
+
+    form.style.display = 'none';
+    successDiv.style.display = 'block';
     form.reset();
 }

--- a/AbueTech/curso_basico.html
+++ b/AbueTech/curso_basico.html
@@ -3,20 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AbueTech - Cursos</title>
-    <meta name="description" content="Listado de cursos de tecnología para todos los niveles.">
-    
-    <!-- Fuentes accesibles -->
+    <title>AbueTech - Curso Básico de Smartphone</title>
+    <meta name="description" content="Aprende paso a paso cómo usar tu teléfono móvil desde cero.">
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="CSS/inicio.css">
 </head>
 <body>
-    <!--JavaScript-->
     <script src="JS/inicio.js"></script>
-    <!-- Enlace de salto para lectores de pantalla -->
     <a href="#main-content" class="skip-link">Ir al contenido principal</a>
 
-    <!-- Barra de accesibilidad -->
     <div class="accessibility-bar">
         <div class="accessibility-controls">
             <span>Accesibilidad:</span>
@@ -35,7 +30,6 @@
         </div>
     </div>
 
-    <!-- Header -->
     <header>
         <nav role="navigation" aria-label="Navegación principal">
             <a href="inicio.html" class="logo" aria-label="AbueTech - Inicio">AbueTech</a>
@@ -54,53 +48,41 @@
         </nav>
     </header>
 
-    <!-- Contenido principal -->
     <main id="main-content">
-        <!-- Hero Section -->
         <section class="hero" id="inicio">
             <div class="fade-in">
-                <h1>Cursos de tecnología para todos</h1>
-                <p>Elige el curso que mejor se adapte a tus necesidades y aprende a tu ritmo.</p>
+                <h1>Curso Básico de Smartphone</h1>
+                <p>Te enseñamos desde encender tu móvil hasta enviar fotos y hablar por video llamada.</p>
             </div>
         </section>
 
         <section class="features">
-            <h2>Listado de cursos</h2>
+            <h2>Lo que aprenderás</h2>
             <div class="features-grid">
                 <article class="feature-card fade-in">
-                    <h3>Curso Básico de Smartphone</h3>
-                    <p>Aprende lo imprescindible para usar tu teléfono móvil desde cero.</p>
-                    <a href="pago.html?course=basico" class="btn-primary">Comprar curso</a>
+                    <img class="feature-icon" src="IMAGES/celular.svg" alt="Imagen de un móvil">
+                    <h3>Encender y configurar tu móvil</h3>
+                    <p>Pasos simples para que tu teléfono quede listo para usar.</p>
                 </article>
-
                 <article class="feature-card fade-in">
-                    <h3>Videollamadas y Redes Sociales</h3>
-                    <p>Conéctate con tus seres queridos a través de las aplicaciones más populares.</p>
-                    <a href="pago.html?course=videollamadas" class="btn-primary">Comprar curso</a>
+                    <img class="feature-icon" src="IMAGES/videollamada.svg" alt="Icono de videollamada">
+                    <h3>Enviar mensajes y hacer llamadas</h3>
+                    <p>Comunícate con tu familia de forma rápida y sencilla.</p>
                 </article>
-
                 <article class="feature-card fade-in">
-                    <h3>Seguridad en Internet</h3>
-                    <p>Protege tus datos personales y navega con tranquilidad.</p>
-                    <a href="pago.html?course=seguridad" class="btn-primary">Comprar curso</a>
-                </article>
-
-                <article class="feature-card fade-in">
-                    <h3>Peligros del uso del Móvil</h3>
-                    <p>Conoce los riesgos más habituales y cómo prevenirlos.</p>
-                    <a href="curso_peligros.html" class="btn-primary">Ver temario</a>
+                    <img class="feature-icon" src="IMAGES/seguridad.svg" alt="Icono de aplicaciones">
+                    <h3>Instalar aplicaciones útiles</h3>
+                    <p>Aprende a descargar apps como WhatsApp y cómo usarlas de manera segura.</p>
                 </article>
             </div>
         </section>
 
-        <!-- CTA Section -->
         <section class="cta-section">
-            <h2>¿Necesitas ayuda para elegir un curso?</h2>
-            <p>Estamos aquí para orientarte y resolver todas tus dudas.</p>
-            <a href="contacto.html" class="btn-primary">Contáctanos</a>
+            <h2>¿Listo para comprar este curso?</h2>
+            <p>Accede a todas las lecciones y aprende a tu ritmo.</p>
+            <a href="pago.html?course=basico" class="btn-primary">Comprar curso</a>
         </section>
 
-        <!-- Newsletter Section -->
         <section class="newsletter">
             <h2>Recibe nuestras guías gratis cada semana</h2>
             <p>Tips, trucos y guías paso a paso directamente en tu correo electrónico</p>
@@ -111,7 +93,6 @@
         </section>
     </main>
 
-    <!-- Footer -->
     <footer>
         <div class="footer-content">
             <div class="footer-section">
@@ -123,7 +104,7 @@
                     <li><a href="comunidad.html">Comunidad</a></li>
                 </ul>
             </div>
-            
+
             <div class="footer-section">
                 <h3>Soporte</h3>
                 <ul>
@@ -133,7 +114,7 @@
                     <li><a href="#ayuda">Centro de ayuda</a></li>
                 </ul>
             </div>
-            
+
             <div class="footer-section">
                 <h3>Síguenos</h3>
                 <p>Más consejos y tutoriales en nuestras redes sociales</p>
@@ -142,7 +123,7 @@
                     <a href="#" class="social-icon" aria-label="Síguenos en YouTube">📺</a>
                 </div>
             </div>
-            
+
             <div class="footer-section">
                 <h3>AbueTech</h3>
                 <p>Tecnología accesible para todos. Aprender nunca fue tan fácil y cercano.</p>
@@ -150,7 +131,7 @@
                 <p><strong>✉️ Email:</strong> info@abuetech.com</p>
             </div>
         </div>
-        
+
         <div class="footer-bottom">
             <p>&copy; 2025 AbueTech.com - Tecnología con amor y paciencia • <a href="#privacidad" style="color: inherit;">Política de Privacidad</a> • <a href="#terminos" style="color: inherit;">Términos de Uso</a></p>
         </div>

--- a/AbueTech/curso_seguridad.html
+++ b/AbueTech/curso_seguridad.html
@@ -3,20 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AbueTech - Cursos</title>
-    <meta name="description" content="Listado de cursos de tecnología para todos los niveles.">
-    
-    <!-- Fuentes accesibles -->
+    <title>AbueTech - Seguridad en Internet</title>
+    <meta name="description" content="Consejos prácticos para proteger tus datos y navegar con tranquilidad.">
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="CSS/inicio.css">
 </head>
 <body>
-    <!--JavaScript-->
     <script src="JS/inicio.js"></script>
-    <!-- Enlace de salto para lectores de pantalla -->
     <a href="#main-content" class="skip-link">Ir al contenido principal</a>
 
-    <!-- Barra de accesibilidad -->
     <div class="accessibility-bar">
         <div class="accessibility-controls">
             <span>Accesibilidad:</span>
@@ -35,7 +30,6 @@
         </div>
     </div>
 
-    <!-- Header -->
     <header>
         <nav role="navigation" aria-label="Navegación principal">
             <a href="inicio.html" class="logo" aria-label="AbueTech - Inicio">AbueTech</a>
@@ -54,53 +48,41 @@
         </nav>
     </header>
 
-    <!-- Contenido principal -->
     <main id="main-content">
-        <!-- Hero Section -->
         <section class="hero" id="inicio">
             <div class="fade-in">
-                <h1>Cursos de tecnología para todos</h1>
-                <p>Elige el curso que mejor se adapte a tus necesidades y aprende a tu ritmo.</p>
+                <h1>Seguridad en Internet</h1>
+                <p>Aprende a proteger tus cuentas y evitar estafas en línea.</p>
             </div>
         </section>
 
         <section class="features">
-            <h2>Listado de cursos</h2>
+            <h2>Lo que aprenderás</h2>
             <div class="features-grid">
                 <article class="feature-card fade-in">
-                    <h3>Curso Básico de Smartphone</h3>
-                    <p>Aprende lo imprescindible para usar tu teléfono móvil desde cero.</p>
-                    <a href="pago.html?course=basico" class="btn-primary">Comprar curso</a>
+                    <img class="feature-icon" src="IMAGES/seguridad.svg" alt="Icono de alerta">
+                    <h3>Reconocer estafas</h3>
+                    <p>Identifica mensajes o llamadas sospechosas que buscan tu dinero.</p>
                 </article>
-
                 <article class="feature-card fade-in">
-                    <h3>Videollamadas y Redes Sociales</h3>
-                    <p>Conéctate con tus seres queridos a través de las aplicaciones más populares.</p>
-                    <a href="pago.html?course=videollamadas" class="btn-primary">Comprar curso</a>
+                    <img class="feature-icon" src="IMAGES/celular.svg" alt="Icono de contraseña">
+                    <h3>Contraseñas seguras</h3>
+                    <p>Crea claves fáciles de recordar pero difíciles de adivinar.</p>
                 </article>
-
                 <article class="feature-card fade-in">
-                    <h3>Seguridad en Internet</h3>
-                    <p>Protege tus datos personales y navega con tranquilidad.</p>
-                    <a href="pago.html?course=seguridad" class="btn-primary">Comprar curso</a>
-                </article>
-
-                <article class="feature-card fade-in">
-                    <h3>Peligros del uso del Móvil</h3>
-                    <p>Conoce los riesgos más habituales y cómo prevenirlos.</p>
-                    <a href="curso_peligros.html" class="btn-primary">Ver temario</a>
+                    <img class="feature-icon" src="IMAGES/videollamada.svg" alt="Icono de privacidad">
+                    <h3>Protege tu información</h3>
+                    <p>Ajusta la configuración de tus aplicaciones para mantener tus datos a salvo.</p>
                 </article>
             </div>
         </section>
 
-        <!-- CTA Section -->
         <section class="cta-section">
-            <h2>¿Necesitas ayuda para elegir un curso?</h2>
-            <p>Estamos aquí para orientarte y resolver todas tus dudas.</p>
-            <a href="contacto.html" class="btn-primary">Contáctanos</a>
+            <h2>¿Listo para comprar este curso?</h2>
+            <p>Accede a todas las lecciones y aprende a tu ritmo.</p>
+            <a href="pago.html?course=seguridad" class="btn-primary">Comprar curso</a>
         </section>
 
-        <!-- Newsletter Section -->
         <section class="newsletter">
             <h2>Recibe nuestras guías gratis cada semana</h2>
             <p>Tips, trucos y guías paso a paso directamente en tu correo electrónico</p>
@@ -111,7 +93,6 @@
         </section>
     </main>
 
-    <!-- Footer -->
     <footer>
         <div class="footer-content">
             <div class="footer-section">
@@ -123,7 +104,7 @@
                     <li><a href="comunidad.html">Comunidad</a></li>
                 </ul>
             </div>
-            
+
             <div class="footer-section">
                 <h3>Soporte</h3>
                 <ul>
@@ -133,7 +114,7 @@
                     <li><a href="#ayuda">Centro de ayuda</a></li>
                 </ul>
             </div>
-            
+
             <div class="footer-section">
                 <h3>Síguenos</h3>
                 <p>Más consejos y tutoriales en nuestras redes sociales</p>
@@ -142,7 +123,7 @@
                     <a href="#" class="social-icon" aria-label="Síguenos en YouTube">📺</a>
                 </div>
             </div>
-            
+
             <div class="footer-section">
                 <h3>AbueTech</h3>
                 <p>Tecnología accesible para todos. Aprender nunca fue tan fácil y cercano.</p>
@@ -150,7 +131,7 @@
                 <p><strong>✉️ Email:</strong> info@abuetech.com</p>
             </div>
         </div>
-        
+
         <div class="footer-bottom">
             <p>&copy; 2025 AbueTech.com - Tecnología con amor y paciencia • <a href="#privacidad" style="color: inherit;">Política de Privacidad</a> • <a href="#terminos" style="color: inherit;">Términos de Uso</a></p>
         </div>

--- a/AbueTech/curso_videollamadas.html
+++ b/AbueTech/curso_videollamadas.html
@@ -3,20 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AbueTech - Cursos</title>
-    <meta name="description" content="Listado de cursos de tecnología para todos los niveles.">
-    
-    <!-- Fuentes accesibles -->
+    <title>AbueTech - Videollamadas y Redes Sociales</title>
+    <meta name="description" content="Domina las principales aplicaciones de videollamadas y redes sociales para estar cerca de tu familia.">
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="CSS/inicio.css">
 </head>
 <body>
-    <!--JavaScript-->
     <script src="JS/inicio.js"></script>
-    <!-- Enlace de salto para lectores de pantalla -->
     <a href="#main-content" class="skip-link">Ir al contenido principal</a>
 
-    <!-- Barra de accesibilidad -->
     <div class="accessibility-bar">
         <div class="accessibility-controls">
             <span>Accesibilidad:</span>
@@ -35,7 +30,6 @@
         </div>
     </div>
 
-    <!-- Header -->
     <header>
         <nav role="navigation" aria-label="Navegación principal">
             <a href="inicio.html" class="logo" aria-label="AbueTech - Inicio">AbueTech</a>
@@ -54,53 +48,41 @@
         </nav>
     </header>
 
-    <!-- Contenido principal -->
     <main id="main-content">
-        <!-- Hero Section -->
         <section class="hero" id="inicio">
             <div class="fade-in">
-                <h1>Cursos de tecnología para todos</h1>
-                <p>Elige el curso que mejor se adapte a tus necesidades y aprende a tu ritmo.</p>
+                <h1>Videollamadas y Redes Sociales</h1>
+                <p>Aprende a conectarte por WhatsApp, Zoom y Facebook de forma sencilla.</p>
             </div>
         </section>
 
         <section class="features">
-            <h2>Listado de cursos</h2>
+            <h2>Lo que aprenderás</h2>
             <div class="features-grid">
                 <article class="feature-card fade-in">
-                    <h3>Curso Básico de Smartphone</h3>
-                    <p>Aprende lo imprescindible para usar tu teléfono móvil desde cero.</p>
-                    <a href="pago.html?course=basico" class="btn-primary">Comprar curso</a>
+                    <img class="feature-icon" src="IMAGES/videollamada.svg" alt="Icono de videollamada">
+                    <h3>Manejar WhatsApp</h3>
+                    <p>Envia mensajes y haz videollamadas con tus seres queridos.</p>
                 </article>
-
                 <article class="feature-card fade-in">
-                    <h3>Videollamadas y Redes Sociales</h3>
-                    <p>Conéctate con tus seres queridos a través de las aplicaciones más populares.</p>
-                    <a href="pago.html?course=videollamadas" class="btn-primary">Comprar curso</a>
+                    <img class="feature-icon" src="IMAGES/celular.svg" alt="Imagen de un móvil">
+                    <h3>Reuniones por Zoom</h3>
+                    <p>Participa en llamadas grupales paso a paso.</p>
                 </article>
-
                 <article class="feature-card fade-in">
-                    <h3>Seguridad en Internet</h3>
-                    <p>Protege tus datos personales y navega con tranquilidad.</p>
-                    <a href="pago.html?course=seguridad" class="btn-primary">Comprar curso</a>
-                </article>
-
-                <article class="feature-card fade-in">
-                    <h3>Peligros del uso del Móvil</h3>
-                    <p>Conoce los riesgos más habituales y cómo prevenirlos.</p>
-                    <a href="curso_peligros.html" class="btn-primary">Ver temario</a>
+                    <img class="feature-icon" src="IMAGES/seguridad.svg" alt="Icono de redes sociales">
+                    <h3>Compartir fotos en Facebook</h3>
+                    <p>Publica y comenta de forma segura en tu red social favorita.</p>
                 </article>
             </div>
         </section>
 
-        <!-- CTA Section -->
         <section class="cta-section">
-            <h2>¿Necesitas ayuda para elegir un curso?</h2>
-            <p>Estamos aquí para orientarte y resolver todas tus dudas.</p>
-            <a href="contacto.html" class="btn-primary">Contáctanos</a>
+            <h2>¿Listo para comprar este curso?</h2>
+            <p>Accede a todas las lecciones y aprende a tu ritmo.</p>
+            <a href="pago.html?course=videollamadas" class="btn-primary">Comprar curso</a>
         </section>
 
-        <!-- Newsletter Section -->
         <section class="newsletter">
             <h2>Recibe nuestras guías gratis cada semana</h2>
             <p>Tips, trucos y guías paso a paso directamente en tu correo electrónico</p>
@@ -111,7 +93,6 @@
         </section>
     </main>
 
-    <!-- Footer -->
     <footer>
         <div class="footer-content">
             <div class="footer-section">
@@ -123,7 +104,7 @@
                     <li><a href="comunidad.html">Comunidad</a></li>
                 </ul>
             </div>
-            
+
             <div class="footer-section">
                 <h3>Soporte</h3>
                 <ul>
@@ -133,7 +114,7 @@
                     <li><a href="#ayuda">Centro de ayuda</a></li>
                 </ul>
             </div>
-            
+
             <div class="footer-section">
                 <h3>Síguenos</h3>
                 <p>Más consejos y tutoriales en nuestras redes sociales</p>
@@ -142,7 +123,7 @@
                     <a href="#" class="social-icon" aria-label="Síguenos en YouTube">📺</a>
                 </div>
             </div>
-            
+
             <div class="footer-section">
                 <h3>AbueTech</h3>
                 <p>Tecnología accesible para todos. Aprender nunca fue tan fácil y cercano.</p>
@@ -150,7 +131,7 @@
                 <p><strong>✉️ Email:</strong> info@abuetech.com</p>
             </div>
         </div>
-        
+
         <div class="footer-bottom">
             <p>&copy; 2025 AbueTech.com - Tecnología con amor y paciencia • <a href="#privacidad" style="color: inherit;">Política de Privacidad</a> • <a href="#terminos" style="color: inherit;">Términos de Uso</a></p>
         </div>

--- a/AbueTech/pago.html
+++ b/AbueTech/pago.html
@@ -76,6 +76,10 @@
                 </label>
                 <button type="submit">Pagar</button>
             </form>
+            <div id="payment-success" style="display:none; text-align:center; margin-top:20px;">
+                <p id="success-message"></p>
+                <p><a id="course-link" class="btn-primary" href="#">Ir al curso</a></p>
+            </div>
         </section>
 
         <section class="newsletter">


### PR DESCRIPTION
## Summary
- create dedicated course pages for smartphone basics, videollamadas and security
- connect payment page with a simple success message and direct access link
- update JS to show course link after purchase
- wire courses page to pass course info to payment

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684e00dbd94483329c6f7aafddebeb75